### PR TITLE
Measure FPS from frame time to avoid sync caps

### DIFF
--- a/include/mbgl/map/map_observer.hpp
+++ b/include/mbgl/map/map_observer.hpp
@@ -42,6 +42,7 @@ public:
         RenderMode mode;
         bool needsRepaint; // In continous mode, shows that there are ongoig transitions.
         bool placementChanged;
+        std::int64_t frameTimeNanos;
     };
 
     virtual void onCameraWillChange(CameraChangeMode) {}

--- a/include/mbgl/renderer/renderer_observer.hpp
+++ b/include/mbgl/renderer/renderer_observer.hpp
@@ -35,6 +35,11 @@ public:
     /// End of frame, booleans flags that a repaint is required and that placement changed.
     virtual void onDidFinishRenderingFrame(RenderMode, bool /*repaint*/, bool /*placementChanged*/) {}
 
+    /// End of frame, booleans flags that a repaint is required and that placement changed.
+    virtual void onDidFinishRenderingFrame(RenderMode mode, bool repaint, bool placementChanged, std::int64_t /*frameTimeNanos*/) {
+        onDidFinishRenderingFrame(mode, repaint, placementChanged);
+    }
+
     /// Final frame
     virtual void onDidFinishRenderingMap() {}
 

--- a/platform/default/src/mbgl/map/map_snapshotter.cpp
+++ b/platform/default/src/mbgl/map/map_snapshotter.cpp
@@ -36,8 +36,9 @@ public:
 
     void onResourceError(std::exception_ptr err) override { delegate.invoke(&RendererObserver::onResourceError, err); }
 
-    void onDidFinishRenderingFrame(RenderMode mode, bool repaintNeeded, bool placementChanged) override {
-        delegate.invoke(&RendererObserver::onDidFinishRenderingFrame, mode, repaintNeeded, placementChanged);
+    void onDidFinishRenderingFrame(RenderMode mode, bool repaintNeeded, bool placementChanged, std::int64_t frameTimeNanos) override {
+        void(RendererObserver::*f)(RenderMode,bool,bool,std::int64_t) = &RendererObserver::onDidFinishRenderingFrame;
+        delegate.invoke(f, mode, repaintNeeded, placementChanged, frameTimeNanos);
     }
 
     void onStyleImageMissing(const std::string& image, const StyleImageMissingCallback& cb) override {
@@ -75,6 +76,13 @@ public:
             stillImage = frontend.readStillImage();
         }
         rendererObserver->onDidFinishRenderingFrame(mode, repaintNeeded, placementChanged);
+    }
+
+    void onDidFinishRenderingFrame(RenderMode mode, bool repaintNeeded, bool placementChanged, std::int64_t frameTimeNanos) override {
+        if (mode == RenderMode::Full && hasPendingStillImageRequest) {
+            stillImage = frontend.readStillImage();
+        }
+        rendererObserver->onDidFinishRenderingFrame(mode, repaintNeeded, placementChanged, frameTimeNanos);
     }
 
     void onStyleImageMissing(const std::string& id, const StyleImageMissingCallback& done) override {

--- a/platform/ios/benchmark/MBXBenchViewController.mm
+++ b/platform/ios/benchmark/MBXBenchViewController.mm
@@ -129,19 +129,17 @@ static const int benchmarkDuration = 200; // frames
         // Do nothing. The benchmark is completed.
         NSLog(@"Benchmark completed.");
         NSLog(@"Result:");
-        double totalFPS = 0;
         double totalFrameTime = 0;
         size_t colWidth = 0;
         for (const auto& row : result) {
             colWidth = std::max(row.first.size(), colWidth);
         }
         for (const auto& row : result) {
-            NSLog(@"| %-*s | %4.1f ms | %4.1f fps |", int(colWidth), row.first.c_str(), 1e3 / row.second, row.second);
-            totalFPS += row.second;
-            totalFrameTime += 1.0 / row.second;
+            NSLog(@"| %-*s | %4.1f ms | %4.1f fps |", int(colWidth), row.first.c_str(), 1e3 * row.second, 1.0 / row.second);
+            totalFrameTime += row.second;
         }
         NSLog(@"Average frame time: %4.1f ms", totalFrameTime * 1e3 / result.size());
-        NSLog(@"Average FPS: %4.1f", totalFPS / result.size());
+        NSLog(@"Average FPS: %4.1f", result.size() / totalFrameTime);
 
         // this does not shut the application down correctly,
         // and results in an assertion failure in thread-local code
@@ -180,7 +178,7 @@ static const int benchmarkDuration = 200; // frames
             const auto wallClockFPS = double(frames * 1e6) / duration;
             const auto frameTime = static_cast<double>(totalFrameNanos) / frames * 1.0e-9;
             const auto potentialFPS = 1.0 / frameTime;
-            result.emplace_back(mbgl::bench::locations[idx].name, potentialFPS);
+            result.emplace_back(mbgl::bench::locations[idx].name, frameTime);
             NSLog(@"- Frame time: %.1f ms, FPS: %.1f (%.1f)", frameTime * 1e3, potentialFPS, wallClockFPS);
 
             // Start benchmarking the next location.

--- a/platform/ios/benchmark/MBXBenchViewController.mm
+++ b/platform/ios/benchmark/MBXBenchViewController.mm
@@ -130,15 +130,17 @@ static const int benchmarkDuration = 200; // frames
         NSLog(@"Benchmark completed.");
         NSLog(@"Result:");
         double totalFPS = 0;
+        double totalFrameTime = 0;
         size_t colWidth = 0;
         for (const auto& row : result) {
             colWidth = std::max(row.first.size(), colWidth);
         }
         for (const auto& row : result) {
-            NSLog(@"| %-*s | %4.1f fps |", int(colWidth), row.first.c_str(), row.second);
+            NSLog(@"| %-*s | %4.1f ms | %4.1f fps |", int(colWidth), row.first.c_str(), 1e3 / row.second, row.second);
             totalFPS += row.second;
+            totalFrameTime += 1.0 / row.second;
         }
-        NSLog(@"Total FPS: %4.1f", totalFPS);
+        NSLog(@"Average frame time: %4.1f ms", totalFrameTime * 1e3 / result.size());
         NSLog(@"Average FPS: %4.1f", totalFPS / result.size());
 
         // this does not shut the application down correctly,
@@ -176,9 +178,10 @@ static const int benchmarkDuration = 200; // frames
             // Report FPS
             const auto duration = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - started).count();
             const auto wallClockFPS = double(frames * 1e6) / duration;
-            const auto potentialFPS = frames / static_cast<double>(totalFrameNanos) * 1.0e9;
+            const auto frameTime = static_cast<double>(totalFrameNanos) / frames * 1.0e-9;
+            const auto potentialFPS = 1.0 / frameTime;
             result.emplace_back(mbgl::bench::locations[idx].name, potentialFPS);
-            NSLog(@"- FPS: %.1f (%.1f)", potentialFPS, wallClockFPS);
+            NSLog(@"- Frame time: %.1f ms, FPS: %.1f (%.1f)", frameTime * 1e3, potentialFPS, wallClockFPS);
 
             // Start benchmarking the next location.
             idx++;

--- a/platform/ios/src/MLNMapView+Impl.mm
+++ b/platform/ios/src/MLNMapView+Impl.mm
@@ -71,7 +71,7 @@ void MLNMapViewImpl::onWillStartRenderingFrame() {
 
 void MLNMapViewImpl::onDidFinishRenderingFrame(mbgl::MapObserver::RenderFrameStatus status) {
     bool fullyRendered = status.mode == mbgl::MapObserver::RenderMode::Full;
-    [mapView mapViewDidFinishRenderingFrameFullyRendered:fullyRendered];
+    [mapView mapViewDidFinishRenderingFrameFullyRendered:fullyRendered frameTimeNanos:status.frameTimeNanos];
 }
 
 void MLNMapViewImpl::onWillStartRenderingMap() {

--- a/platform/ios/src/MLNMapView.mm
+++ b/platform/ios/src/MLNMapView.mm
@@ -6812,7 +6812,8 @@ static void *windowScreenContext = &windowScreenContext;
     }
 }
 
-- (void)mapViewDidFinishRenderingFrameFullyRendered:(BOOL)fullyRendered {
+- (void)mapViewDidFinishRenderingFrameFullyRendered:(BOOL)fullyRendered
+                                     frameTimeNanos:(long long)frameTimeNanos {
     if (!_mbglMap)
     {
         return;
@@ -6824,7 +6825,11 @@ static void *windowScreenContext = &windowScreenContext;
         [self.style didChangeValueForKey:@"layers"];
     }
 
-    if ([self.delegate respondsToSelector:@selector(mapViewDidFinishRenderingFrame:fullyRendered:)])
+    if ([self.delegate respondsToSelector:@selector(mapViewDidFinishRenderingFrame:fullyRendered:frameTimeNanos:)])
+    {
+        [self.delegate mapViewDidFinishRenderingFrame:self fullyRendered:fullyRendered frameTimeNanos:frameTimeNanos];
+    }
+    else if ([self.delegate respondsToSelector:@selector(mapViewDidFinishRenderingFrame:fullyRendered:)])
     {
         [self.delegate mapViewDidFinishRenderingFrame:self fullyRendered:fullyRendered];
     }

--- a/platform/ios/src/MLNMapViewDelegate.h
+++ b/platform/ios/src/MLNMapViewDelegate.h
@@ -241,6 +241,21 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)mapViewDidFinishRenderingFrame:(MLNMapView *)mapView fullyRendered:(BOOL)fullyRendered;
 
 /**
+ Tells the delegate that the map view has just redrawn.
+
+ This method is called any time the map view needs to redraw due to a change in
+ the viewpoint or style property transition. This method may be called very
+ frequently, even moreso than `-mapViewRegionIsChanging:`. Therefore, your
+ implementation of this method should be as lightweight as possible to avoid
+ affecting performance.
+
+ @param mapView The map view that has just redrawn.
+ @param frameTimeNanos The time taken to render the frame, in nanoseconds
+ */
+- (void)mapViewDidFinishRenderingFrame:(MLNMapView *)mapView fullyRendered:(BOOL)fullyRendered
+                        frameTimeNanos:(long long)frameTimeNanos;
+
+/**
  Tells the delegate that the map view is entering an idle state, and no more
  drawing will be necessary until new data is loaded or there is some interaction
  with the map.

--- a/platform/ios/src/MLNMapView_Private.h
+++ b/platform/ios/src/MLNMapView_Private.h
@@ -37,7 +37,8 @@ FOUNDATION_EXTERN MLN_EXPORT MLNExceptionName const _Nonnull MLNUnderlyingMapUna
 - (void)mapViewDidFinishLoadingMap;
 - (void)mapViewDidFailLoadingMapWithError:(nonnull NSError *)error;
 - (void)mapViewWillStartRenderingFrame;
-- (void)mapViewDidFinishRenderingFrameFullyRendered:(BOOL)fullyRendered;
+- (void)mapViewDidFinishRenderingFrameFullyRendered:(BOOL)fullyRendered
+                                     frameTimeNanos:(long long)frameTimeNanos;
 - (void)mapViewWillStartRenderingMap;
 - (void)mapViewDidFinishRenderingMapFullyRendered:(BOOL)fullyRendered;
 - (void)mapViewDidBecomeIdle;

--- a/src/mbgl/map/map_impl.cpp
+++ b/src/mbgl/map/map_impl.cpp
@@ -128,11 +128,11 @@ void Map::Impl::onWillStartRenderingFrame() {
     }
 }
 
-void Map::Impl::onDidFinishRenderingFrame(RenderMode renderMode, bool needsRepaint, bool placemenChanged) {
+void Map::Impl::onDidFinishRenderingFrame(RenderMode renderMode, bool needsRepaint, bool placemenChanged, std::int64_t frameTimeNanos) {
     rendererFullyLoaded = renderMode == RenderMode::Full;
 
     if (mode == MapMode::Continuous) {
-        observer.onDidFinishRenderingFrame({MapObserver::RenderMode(renderMode), needsRepaint, placemenChanged});
+        observer.onDidFinishRenderingFrame({MapObserver::RenderMode(renderMode), needsRepaint, placemenChanged, frameTimeNanos});
 
         if (needsRepaint || transform.inTransition()) {
             onUpdate();

--- a/src/mbgl/map/map_impl.hpp
+++ b/src/mbgl/map/map_impl.hpp
@@ -45,7 +45,7 @@ public:
     void onInvalidate() final;
     void onResourceError(std::exception_ptr) final;
     void onWillStartRenderingFrame() final;
-    void onDidFinishRenderingFrame(RenderMode, bool, bool) final;
+    void onDidFinishRenderingFrame(RenderMode, bool, bool, std::int64_t) final;
     void onWillStartRenderingMap() final;
     void onDidFinishRenderingMap() final;
     void onStyleImageMissing(const std::string&, const std::function<void()>&) final;


### PR DESCRIPTION
This makes thermal state unnecessary and lets meaningful benchmarks run much faster.

```
Benchmarking "germany"
- Loading assets...
- Warming up for 20 frames...
- Benchmarking for 200 frames...
- Frame time: 15.0 ms, FPS: 66.8 (60.1)
Benchmark completed.
Result:
| boston     | 13.1 ms | 76.0 fps |
| paris      |  5.6 ms | 179.5 fps |
| paris2     | 14.9 ms | 66.9 fps |
| alps       |  5.4 ms | 184.8 fps |
| us east    | 14.3 ms | 70.0 fps |
| greater la | 14.9 ms | 67.0 fps |
| sf         | 15.8 ms | 63.2 fps |
| oakland    |  5.3 ms | 189.3 fps |
| germany    | 15.0 ms | 66.8 fps |
Average frame time: 11.6 ms
Average FPS: 107.1
```