### PR TITLE
Share interpolation UBOs between symbol drawables and don't replace e…

### DIFF
--- a/include/mbgl/renderer/layer_tweaker.hpp
+++ b/include/mbgl/renderer/layer_tweaker.hpp
@@ -35,6 +35,8 @@ public:
 
     virtual void execute(LayerGroupBase&, const RenderTree&, const PaintParameters&) = 0;
 
+    void updateProperties(Immutable<style::LayerProperties>);
+
 protected:
     /// Calculate matrices for this tile.
     /// @param nearClipped If true, the near plane is moved further to enhance depth buffer precision.
@@ -50,6 +52,7 @@ protected:
 
 protected:
     Immutable<style::LayerProperties> evaluatedProperties;
+    bool propertiesUpdated = true;
 };
 
 } // namespace mbgl

--- a/src/mbgl/gfx/context.hpp
+++ b/src/mbgl/gfx/context.hpp
@@ -143,6 +143,17 @@ public:
 
     /// Resets the context state to defaults
     virtual void resetState(gfx::DepthMode depthMode, gfx::ColorMode colorMode) = 0;
+
+    /// Update the uniform buffer with the provided data if it already exists, otherwise create it.
+    ///  @return True if the buffer was created, false if it was updated
+    virtual bool emplaceOrUpdateUniformBuffer(gfx::UniformBufferPtr&, const void* data, std::size_t size) = 0;
+
+    /// `emplaceOrUpdateUniformBuffer` with type inference
+    template <typename T>
+    std::enable_if_t<!std::is_pointer_v<T>,bool> emplaceOrUpdateUniformBuffer(gfx::UniformBufferPtr& ptr, const T* data) {
+        return emplaceOrUpdateUniformBuffer(ptr, data, sizeof(T));
+    }
+
 #endif
 };
 

--- a/src/mbgl/gl/context.cpp
+++ b/src/mbgl/gl/context.cpp
@@ -432,6 +432,16 @@ void Context::resetState(gfx::DepthMode depthMode, gfx::ColorMode colorMode) {
     setColorMode(colorMode);
     setCullFaceMode(gfx::CullFaceMode::disabled());
 }
+
+bool Context::emplaceOrUpdateUniformBuffer(gfx::UniformBufferPtr& buffer, const void* data, std::size_t size) {
+    if (buffer) {
+        buffer->update(data, size);
+        return false;
+    } else {
+        buffer = createUniformBuffer(data, size);
+        return true;
+    }
+}
 #endif
 
 void Context::setDirtyState() {

--- a/src/mbgl/gl/context.hpp
+++ b/src/mbgl/gl/context.hpp
@@ -121,6 +121,8 @@ public:
     UniqueFramebuffer createFramebuffer(const gfx::Texture2D& color);
 
     void resetState(gfx::DepthMode depthMode, gfx::ColorMode colorMode) override;
+    
+    bool emplaceOrUpdateUniformBuffer(gfx::UniformBufferPtr&, const void* data, std::size_t size) override;
 #endif
 
     void setDirtyState() override;

--- a/src/mbgl/renderer/layer_tweaker.cpp
+++ b/src/mbgl/renderer/layer_tweaker.cpp
@@ -33,4 +33,9 @@ mat4 LayerTweaker::getTileMatrix(const UnwrappedTileID& tileID,
     return RenderTile::translateVtxMatrix(tileID, tileMatrix, translation, anchor, state, inViewportPixelUnits);
 }
 
+void LayerTweaker::updateProperties(Immutable<style::LayerProperties> newProps) {
+    evaluatedProperties = std::move(newProps);
+    propertiesUpdated = true;
+}
+
 } // namespace mbgl

--- a/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
+++ b/src/mbgl/renderer/layers/symbol_layer_tweaker.cpp
@@ -134,14 +134,15 @@ void SymbolLayerTweaker::execute(LayerGroupBase& layerGroup,
         const auto& symbolData = static_cast<gfx::SymbolDrawableData&>(*drawable.getData());
         const auto isText = (symbolData.symbolType == SymbolType::Text);
 
-        if (isText && !textPaintBuffer) {
+        if (isText && (!textPaintBuffer || propertiesUpdated)) {
             const auto props = buildPaintUBO(true, evaluated);
             textPaintBuffer = parameters.context.createUniformBuffer(&props, sizeof(props));
         }
-        if (!isText && !iconPaintBuffer) {
+        else if (!isText && (!iconPaintBuffer || propertiesUpdated)) {
             const auto props = buildPaintUBO(false, evaluated);
             iconPaintBuffer = parameters.context.createUniformBuffer(&props, sizeof(props));
         }
+        propertiesUpdated = false;
 
         // from RenderTile::translatedMatrix
         const auto translate = isText ? evaluated.get<style::TextTranslate>() : evaluated.get<style::IconTranslate>();


### PR DESCRIPTION
…valuated property UBOs on each update to take better advantage of checksums.

This gives me another 5% or so, and should be especially helpful on symbol-heavy views where we're creating a large number of drawables.