### PR TITLE
Move static attribute name IDs from `readDataDrivenPaintProperties` t…

### DIFF
--- a/include/mbgl/gfx/vertex_attribute.hpp
+++ b/include/mbgl/gfx/vertex_attribute.hpp
@@ -358,8 +358,7 @@ public:
             [&](const auto& attributeNames) {
                 for (std::size_t attrIndex = 0; attrIndex < attributeNames.size(); ++attrIndex) {
                     using namespace std::string_literals;
-                    const auto& attributeName = std::string(attributeNames[attrIndex]);
-                    static const StringIdentity attributeNameId = StringIndexer::get("a_"s + attributeName);
+                    const auto& attributeName = attributeNames[attrIndex];
                     if (auto& binder = binders.template get<DataDrivenPaintProperty>()) {
                         using Attribute = typename DataDrivenPaintProperty::Attribute;
                         using Type = typename Attribute::Type; // ::mbgl::gfx::AttributeType<type_, n_>
@@ -368,7 +367,13 @@ public:
                         const auto vertexCount = binder->getVertexCount();
                         const auto isConstant = evaluated.template get<DataDrivenPaintProperty>().isConstant();
                         if (vertexCount > 0 && !isConstant) {
-                            if (auto& attr = getOrAdd(attributeNameId)) {
+                            auto& attributeNameID = DataDrivenPaintProperty::AttributeNameIDs[attrIndex];
+                            if (!attributeNameID) {
+                                static const std::string attributePrefix = "a_";
+                                attributeNameID = StringIndexer::get(attributePrefix + attributeName.data());
+                            }
+
+                            if (auto& attr = getOrAdd(*attributeNameID)) {
                                 if (const auto& sharedVector = binder->getSharedVertexVector()) {
                                     const auto rawSize = static_cast<uint32_t>(sharedVector->getRawSize());
                                     const bool isInterpolated = binder->isInterpolated();

--- a/src/mbgl/style/paint_property.hpp
+++ b/src/mbgl/style/paint_property.hpp
@@ -7,9 +7,14 @@
 #include <mbgl/renderer/cross_faded_property_evaluator.hpp>
 #include <mbgl/renderer/data_driven_property_evaluator.hpp>
 
+#include <array>
+#include <optional>
 #include <utility>
 
 namespace mbgl {
+
+using StringIdentity = std::size_t;
+
 namespace style {
 
 template <class T>
@@ -41,7 +46,11 @@ public:
     using UniformList = TypeList<U>;
 
     static constexpr const std::array<std::string_view, 1> AttributeNames = {A::name()};
+    static std::array<std::optional<StringIdentity>, 1> AttributeNameIDs;
 };
+
+template <class T, class A, class U, bool B>
+std::array<std::optional<StringIdentity>, 1> DataDrivenPaintProperty<T,A,U,B>::AttributeNameIDs = {std::nullopt};
 
 template <class T, class A1, class U1, class A2, class U2>
 class CrossFadedDataDrivenPaintProperty {
@@ -60,7 +69,11 @@ public:
     using UniformList = TypeList<U1, U2>;
 
     static constexpr const std::array<std::string_view, 2> AttributeNames = {A1::name(), A2::name()};
+    static std::array<std::optional<StringIdentity>, 2> AttributeNameIDs;
 };
+
+template <class T, class A1, class U1, class A2, class U2>
+std::array<std::optional<StringIdentity>, 2> CrossFadedDataDrivenPaintProperty<T,A1,U1,A2,U2>::AttributeNameIDs = {std::nullopt,std::nullopt};
 
 template <class T>
 class CrossFadedPaintProperty {


### PR DESCRIPTION
…o the `DataDrivenPaintProperty` classes to fix a problem where a single local static could not retain the ID values for the two attribute names used by `CrossFadedDataDrivenPaintProperty`.

Avoid creating a heap copy of the attribute name string unless it's needed.